### PR TITLE
Update lazy-load.php

### DIFF
--- a/lazy-load.php
+++ b/lazy-load.php
@@ -50,6 +50,11 @@ class LazyLoad_Images {
 		if( is_feed() || is_preview() )
 			return $content;
 
+		$no_lazyload_key = apply_filters( 'no_lazyload_key', 'no-lazyload' );
+
+		if( false !== strpos( $content, $no_lazyload_key ) )
+			return $content;
+
 		// Don't lazy-load if the content has already been run through previously
 		if ( false !== strpos( $content, 'data-lazy-src' ) )
 			return $content;


### PR DESCRIPTION
A simple stupid tweak to be able to disable lazy loading when a specific key is found in the $content.
It can be the name of class which is by default "no-lazyload".
