### PR TITLE
Add Functionality to Disable Lazy Load

### DIFF
--- a/js/lazy-load.js
+++ b/js/lazy-load.js
@@ -7,6 +7,7 @@
 			lazy_load_image( this );
 		});
 
+		// Force load images with the class 'exclude-lazy-load'. Users can add the class to an image and the image will load directly.
 		$( 'img.exclude-lazy-load' ).each( function() {
 			lazy_load_image(this);
 		});

--- a/js/lazy-load.js
+++ b/js/lazy-load.js
@@ -7,6 +7,10 @@
 			lazy_load_image( this );
 		});
 
+		$( 'img.exclude-lazy-load' ).each( function() {
+			lazy_load_image(this);
+		});
+
 		// We need to force load gallery images in Jetpack Carousel and give up lazy-loading otherwise images don't show up correctly
 		$( '[data-carousel-extra]' ).each( function() {
 			$( this ).find( 'img[data-lazy-src]' ).each( function() {


### PR DESCRIPTION
This PR introduces a capability to disable Lazy Load on images with 'exclude-lazy-load'. The user can add the 'exclude-lazy-load' on an image such as the following image, then the image will be directly loaded without Lazy Load. 

<img width="1158" alt="screen shot 2018-02-10 at 22 50 20" src="https://user-images.githubusercontent.com/4124883/36067425-eb845696-0eb4-11e8-8a3c-a80080015dae.png">

This is resolving issue #9.

Open to suggestions on this PR.